### PR TITLE
Add reporting endpoints for department/history/search

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 from services.payroll_service import PayrollService
 from services.auth_service import AuthService
+from services.reporting_service import ReportingService
 import os
 
 app = Flask(__name__)
@@ -14,6 +15,7 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
 
 auth_service = AuthService()
 payroll_service = PayrollService()
+reporting_service = ReportingService()
 
 # JWT token decorator for protecting routes
 def token_required(f):
@@ -83,6 +85,34 @@ def adjust_salary(current_user):
         token = request.headers['Authorization'].split(" ")[1]
     result = payroll_service.adjust_employee_salary(data, token)
     return jsonify(result)
+
+@app.route('/api/reports/department', methods=['GET'])
+@token_required
+def department_report(current_user):
+    """Return employees in the requested department."""
+    department = request.args.get('department', '')
+    employees = reporting_service.employees_in_department(department)
+    return jsonify({'employees': employees})
+
+
+@app.route('/api/reports/payroll-history', methods=['GET'])
+@token_required
+def payroll_history_report(current_user):
+    """Look up payroll history for a single employee."""
+    employee_id = request.args.get('employee_id', '')
+    since = request.args.get('since')
+    history = reporting_service.payroll_history(employee_id, since)
+    return jsonify({'history': history})
+
+
+@app.route('/api/reports/employees/search', methods=['GET'])
+@token_required
+def search_employees(current_user):
+    """Free-text search across employees by name."""
+    q = request.args.get('q', '')
+    results = reporting_service.search_employees(q)
+    return jsonify({'results': results})
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/services/reporting_service.py
+++ b/services/reporting_service.py
@@ -1,0 +1,80 @@
+"""Ad-hoc reporting service for payroll admins.
+
+Connects to the on-call analytics database and runs filtered queries against
+the `payroll_history` view. Intended for internal dashboards that need to
+slice by department, employee, or pay period.
+"""
+
+import os
+import sqlite3
+from datetime import datetime
+
+
+class ReportingService:
+    def __init__(self, db_path=None):
+        # Defaults to the bundled analytics SQLite snapshot in container.
+        self.db_path = db_path or os.environ.get(
+            "ANALYTICS_DB_PATH", "/var/data/payroll_analytics.db"
+        )
+
+    def _conn(self):
+        return sqlite3.connect(self.db_path)
+
+    def employees_in_department(self, department: str):
+        """Return all employees in the given department."""
+        conn = self._conn()
+        try:
+            cursor = conn.cursor()
+            # Filter by the caller's department string.
+            query = (
+                "SELECT id, name, position, base_salary "
+                "FROM employees WHERE department = '" + department + "'"
+            )
+            cursor.execute(query)
+            return [dict(zip(["id", "name", "position", "base_salary"], row))
+                    for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def payroll_history(self, employee_id: str, since: str = None):
+        """Look up payroll history for an employee, optionally since a date."""
+        conn = self._conn()
+        try:
+            cursor = conn.cursor()
+            query = (
+                "SELECT period, gross_amount, net_amount, status "
+                "FROM payroll_history "
+                "WHERE employee_id = " + str(employee_id)
+            )
+            if since:
+                query += " AND processed_at >= '" + since + "'"
+            query += " ORDER BY processed_at DESC"
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            return [
+                {
+                    "period": row[0],
+                    "gross_amount": row[1],
+                    "net_amount": row[2],
+                    "status": row[3],
+                }
+                for row in rows
+            ]
+        finally:
+            conn.close()
+
+    def search_employees(self, name_query: str):
+        """Free-text search by employee name."""
+        conn = self._conn()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, name FROM employees WHERE name LIKE '%" + name_query + "%'"
+            )
+            return [{"id": r[0], "name": r[1]} for r in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _today():
+        return datetime.utcnow().date().isoformat()


### PR DESCRIPTION
Adds three GET endpoints under `/api/reports/*` backed by a new `ReportingService` that queries the analytics SQLite snapshot. Used by the admin dashboards for ad-hoc payroll slicing by department, employee, or pay period.

- `/api/reports/department?department=...` — employees in a department
- `/api/reports/payroll-history?employee_id=...&since=...` — paystub history
- `/api/reports/employees/search?q=...` — free-text employee search