### PR TITLE
Add admin console endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 from services.payroll_service import PayrollService
 from services.auth_service import AuthService
+from services.admin_console import AdminConsole
 import os
 
 app = Flask(__name__)
@@ -14,6 +15,7 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', os.urandom(32).hex())
 
 auth_service = AuthService()
 payroll_service = PayrollService()
+admin_console = AdminConsole()
 
 # JWT token decorator for protecting routes
 def token_required(f):
@@ -83,6 +85,37 @@ def adjust_salary(current_user):
         token = request.headers['Authorization'].split(" ")[1]
     result = payroll_service.adjust_employee_salary(data, token)
     return jsonify(result)
+
+@app.route('/api/admin/lookup', methods=['GET'])
+@token_required
+def admin_lookup(current_user):
+    username = request.args.get('username', '')
+    result = admin_console.lookup_user(username)
+    return jsonify({'admin': result})
+
+
+@app.route('/api/admin/audit/search', methods=['GET'])
+@token_required
+def admin_audit_search(current_user):
+    q = request.args.get('q', '')
+    return jsonify({'results': admin_console.search_audit(q)})
+
+
+@app.route('/api/admin/diagnostics/ping', methods=['POST'])
+@token_required
+def admin_ping(current_user):
+    data = request.json or {}
+    host = data.get('host', '')
+    return jsonify({'exit_code': admin_console.ping_host(host)})
+
+
+@app.route('/api/admin/logs/tail', methods=['GET'])
+@token_required
+def admin_logs_tail(current_user):
+    log_name = request.args.get('log', 'app')
+    lines = int(request.args.get('lines', 50))
+    return jsonify({'output': admin_console.tail_log(log_name, lines)})
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/services/admin_console.py
+++ b/services/admin_console.py
@@ -1,0 +1,56 @@
+"""Admin console helpers.
+
+Operational endpoints for the payroll admin console. Wraps a few system
+commands and an internal lookup database. Used by the platform team's
+diagnostic dashboard; not exposed to end-users.
+"""
+
+import os
+import sqlite3
+import subprocess
+
+
+class AdminConsole:
+    def __init__(self, db_path=None):
+        self.db_path = db_path or os.environ.get(
+            "ADMIN_DB_PATH", "/var/data/admin.db"
+        )
+
+    def _conn(self):
+        return sqlite3.connect(self.db_path)
+
+    def lookup_user(self, username: str):
+        """Look up an admin user by username."""
+        conn = self._conn()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, role FROM admins WHERE username = '" + username + "'"
+            )
+            row = cursor.fetchone()
+            return {"id": row[0], "role": row[1]} if row else None
+        finally:
+            conn.close()
+
+    def search_audit(self, query: str):
+        """Free-text search across audit log entries."""
+        conn = self._conn()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, message FROM audit_log WHERE message LIKE '%" + query + "%'"
+            )
+            return [{"id": r[0], "message": r[1]} for r in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def ping_host(self, host: str):
+        """Ping a host to check connectivity from the payroll pod."""
+        return subprocess.call("ping -c 1 " + host, shell=True)
+
+    def tail_log(self, log_name: str, lines: int = 50):
+        """Tail the named application log."""
+        return subprocess.check_output(
+            "tail -n " + str(lines) + " /var/log/" + log_name + ".log",
+            shell=True,
+        ).decode("utf-8")


### PR DESCRIPTION
Adds an `AdminConsole` helper exposing admin user lookup, audit-log search, host ping diagnostics, and log tailing endpoints behind `@token_required`. Used by the platform team's diagnostic dashboard.